### PR TITLE
Fix go get link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the Magic: The Gathering SDK Go implementation. It is a wrapper around t
 
 Just run
 
-`go get https://github.com/MagicTheGathering/mtg-sdk-go`
+`go get github.com/MagicTheGathering/mtg-sdk-go`
 
 ## Docs
 


### PR DESCRIPTION
https not allowed in go get:

```
lex@laptop:~/golang$ go get https://github.com/MagicTheGathering/mtg-sdk-go
package https:/github.com/MagicTheGathering/mtg-sdk-go: "https://" not allowed in import path
✗: 1 @ Wed Sep  5 13:12:52 MSK 2018
lex@laptop:~/golang$ go get github.com/MagicTheGathering/mtg-sdk-go
✓ @ Wed Sep  5 13:13:03 MSK 2018
```