### PR TITLE
fix card multiverseid type so to work with the actual type from api

### DIFF
--- a/card.go
+++ b/card.go
@@ -107,7 +107,7 @@ type Card struct {
 	// The card layout. Possible values: normal, split, flip, double-faced, token, plane, scheme, phenomenon, leveler, vanguard
 	Layout string `json:"layout"`
 	// The multiverseid of the card on Wizard’s Gatherer web page. Cards from sets that do not exist on Gatherer will NOT have a multiverseid. Sets not on Gatherer are: ATH, ITP, DKM, RQS, DPA and all sets with a 4 letter code that starts with a lowercase 'p’.
-	MultiverseId MultiverseId `json:"multiverseid"`
+	MultiverseId string `json:"multiverseid"`
 	// If a card has alternate art (for example, 4 different Forests, or the 2 Brothers Yamazaki) then each other variation’s multiverseid will be listed here, NOT including the current card’s multiverseid.
 	Variations []string `json:"variations"`
 	// The image url for a card. Only exists if the card has a multiverse id.


### PR DESCRIPTION
As the title says, the current type for card.MultiverseId is not correct, go sdk expect `uint32` but the api response with a `string`.